### PR TITLE
Support LADSPA

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -366,7 +366,7 @@ jobs:
           libx11-dev libxrandr-dev libxinerama-dev \
           libxrender-dev libxcomposite-dev libxcb-xinerama0-dev \
           libxcursor-dev libfreetype6 libfreetype6-dev \
-          libasound2-dev
+          libasound2-dev ladspa-sdk
       # We depend on ccache features that are only present in 4.8.0 and later, but installing from apt-get gives us v3.
       - name: Install ccache on Linux
         if: runner.os == 'Linux'
@@ -491,7 +491,7 @@ jobs:
           libx11-dev libxrandr-dev libxinerama-dev \
           libxrender-dev libxcomposite-dev libxcb-xinerama0-dev \
           libxcursor-dev libfreetype6 libfreetype6-dev \
-          libasound2-dev
+          libasound2-dev ladspa-sdk
       # We depend on ccache features that are only present in 4.8.0 and later, but installing from apt-get gives us v3.
       - name: Install ccache on Linux
         if: runner.os == 'Linux'

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -75,7 +75,7 @@ jobs:
           libx11-dev libxrandr-dev libxinerama-dev \
           libxrender-dev libxcomposite-dev libxcb-xinerama0-dev \
           libxcursor-dev libfreetype6 libfreetype6-dev \
-          libasound2-dev
+          libasound2-dev ladspa-sdk
       # We depend on ccache features that are only present in 4.8.0 and later, but installing from apt-get gives us v3.
       - name: Install ccache on Linux
         if: runner.os == 'Linux'
@@ -259,7 +259,7 @@ jobs:
           libx11-dev libxrandr-dev libxinerama-dev \
           libxrender-dev libxcomposite-dev libxcb-xinerama0-dev \
           libxcursor-dev libfreetype6 libfreetype6-dev \
-          libasound2-dev
+          libasound2-dev ladspa-sdk
       # We depend on ccache features that are only present in 4.8.0 and later, but installing from apt-get gives us v3.
       - name: Install ccache on Linux
         if: runner.os == 'Linux'
@@ -623,7 +623,7 @@ jobs:
           libx11-dev libxrandr-dev libxinerama-dev \
           libxrender-dev libxcomposite-dev libxcb-xinerama0-dev \
           libxcursor-dev libfreetype6 libfreetype6-dev \
-          libasound2-dev
+          libasound2-dev ladspa-sdk
       # We depend on ccache features that are only present in 4.8.0 and later, but installing from apt-get gives us v3.
       - name: Install ccache on Linux
         if: runner.os == 'Linux'

--- a/pedalboard/ExternalPlugin.h
+++ b/pedalboard/ExternalPlugin.h
@@ -798,7 +798,7 @@ public:
 
     if (savedState.getSize() > 0) {
       pluginInstance->setStateInformation(savedState.getData(),
-                                        savedState.getSize());
+                                          savedState.getSize());
 
       // Set all of the parameters twice: we may have meta-parameters that
       // change the validity of other `setValue` calls. (i.e.: param1 can't be
@@ -2094,8 +2094,7 @@ see :class:`pedalboard.VST3Plugin`.)
 #endif
 
 #if JUCE_LINUX
-  py::class_<ExternalPlugin<juce::LADSPAPluginFormat>,
-             AbstractExternalPlugin,
+  py::class_<ExternalPlugin<juce::LADSPAPluginFormat>, AbstractExternalPlugin,
              std::shared_ptr<ExternalPlugin<juce::LADSPAPluginFormat>>>(
       m, "LADSPAPlugin",
       R"(A wrapper around third-party, audio effect or instrument plugins in
@@ -2121,9 +2120,8 @@ example: a Linux LADSPA plugin bundle will not load on Windows or macOS.)
           py::init([](std::string &pathToPluginFile, py::object parameterValues,
                       std::optional<std::string> pluginName,
                       float initializationTimeout) {
-            std::shared_ptr<ExternalPlugin<juce::LADSPAPluginFormat>>
-                plugin = std::make_shared<
-                    ExternalPlugin<juce::LADSPAPluginFormat>>(
+            std::shared_ptr<ExternalPlugin<juce::LADSPAPluginFormat>> plugin =
+                std::make_shared<ExternalPlugin<juce::LADSPAPluginFormat>>(
                     pathToPluginFile, pluginName, initializationTimeout);
             py::cast(plugin).attr("__set_initial_parameter_values__")(
                 parameterValues);
@@ -2255,8 +2253,7 @@ example: a Linux LADSPA plugin bundle will not load on Windows or macOS.)
       .def("_get_parameter",
            &ExternalPlugin<juce::LADSPAPluginFormat>::getParameter,
            py::return_value_policy::reference_internal)
-      .def("show_editor",
-           &ExternalPlugin<juce::LADSPAPluginFormat>::showEditor,
+      .def("show_editor", &ExternalPlugin<juce::LADSPAPluginFormat>::showEditor,
            SHOW_EDITOR_DOCSTRING, py::arg("close_event") = py::none())
       .def(
           "process",
@@ -2293,8 +2290,7 @@ example: a Linux LADSPA plugin bundle will not load on Windows or macOS.)
            py::arg("buffer_size") = DEFAULT_BUFFER_SIZE,
            py::arg("reset") = true)
       .def_readwrite(
-          "_reload_type",
-          &ExternalPlugin<juce::LADSPAPluginFormat>::reloadType,
+          "_reload_type", &ExternalPlugin<juce::LADSPAPluginFormat>::reloadType,
           "The behavior that this plugin exhibits when .reset() is called. "
           "This is an internal attribute which gets set on plugin "
           "instantiation and should only be accessed for debugging and "

--- a/pedalboard/ExternalPlugin.h
+++ b/pedalboard/ExternalPlugin.h
@@ -180,6 +180,18 @@ inline std::vector<std::string> findInstalledVSTPluginPaths() {
   return pluginPaths;
 }
 
+inline std::vector<std::string> findInstalledLADSPAPluginPaths() {
+  juce::MessageManager::getInstance();
+  juce::LADSPAPluginFormat format;
+  std::vector<std::string> pluginPaths;
+  for (juce::String pluginIdentifier : format.searchPathsForPlugins(
+           format.getDefaultLocationsToSearch(), true, false)) {
+    pluginPaths.push_back(
+        format.getNameOfPluginFromIdentifier(pluginIdentifier).toStdString());
+  }
+  return pluginPaths;
+}
+
 /**
  * Given a py::object representing a Python list object filled with Tuple[bytes,
  * float], each representing a MIDI message at a specific timestamp, return a
@@ -784,19 +796,24 @@ public:
       NUM_ACTIVE_EXTERNAL_PLUGINS++;
     }
 
-    pluginInstance->setStateInformation(savedState.getData(),
+    if (savedState.getSize() > 0) {
+      pluginInstance->setStateInformation(savedState.getData(),
                                         savedState.getSize());
 
-    // Set all of the parameters twice: we may have meta-parameters that
-    // change the validity of other `setValue` calls. (i.e.: param1 can't be
-    // set until param2 is set.)
-    for (int i = 0; i < 2; i++) {
-      for (auto *parameter : pluginInstance->getParameters()) {
-        if (currentParameters.count(parameter->getParameterIndex()) > 0) {
-          parameter->setValue(
-              currentParameters[parameter->getParameterIndex()]);
+      // Set all of the parameters twice: we may have meta-parameters that
+      // change the validity of other `setValue` calls. (i.e.: param1 can't be
+      // set until param2 is set.)
+      for (int i = 0; i < 2; i++) {
+        for (auto *parameter : pluginInstance->getParameters()) {
+          if (currentParameters.count(parameter->getParameterIndex()) > 0) {
+            parameter->setValue(
+                currentParameters[parameter->getParameterIndex()]);
+          }
         }
       }
+    } else {
+      // TODO: add log if needed
+      std::cout << "No previous state to restore" << std::endl;
     }
 
     if (lastSpec.numChannels != 0) {
@@ -2070,6 +2087,214 @@ see :class:`pedalboard.VST3Plugin`.)
       .def_readwrite(
           "_reload_type",
           &ExternalPlugin<juce::AudioUnitPluginFormat>::reloadType,
+          "The behavior that this plugin exhibits when .reset() is called. "
+          "This is an internal attribute which gets set on plugin "
+          "instantiation and should only be accessed for debugging and "
+          "testing.");
+#endif
+
+#if JUCE_LINUX
+  py::class_<ExternalPlugin<juce::LADSPAPluginFormat>,
+             AbstractExternalPlugin,
+             std::shared_ptr<ExternalPlugin<juce::LADSPAPluginFormat>>>(
+      m, "LADSPAPlugin",
+      R"(A wrapper around third-party, audio effect or instrument plugins in
+`LADSPA <https://en.wikipedia.org/wiki/LADSPA>`_ format.
+
+LADSPA plugins are supported on Linux. However, LADSPA plugin
+files are not cross-compatible with different operating systems; a platform-specific
+build of each plugin is required to load that plugin on a given platform. (For
+example: a Linux LADSPA plugin bundle will not load on Windows or macOS.)
+
+.. warning::
+    Some LADSPA plugins may throw errors, hang, generate incorrect output, or
+    outright crash if called from background threads. If you find that a LADSPA
+    plugin is not working as expected, try calling it from the main thread
+    instead and `open a GitHub Issue to track the incompatibility
+    <https://github.com/spotify/pedalboard/issues/new>`_.
+
+*Support for instrument plugins introduced in v0.7.4.*
+
+*Support for running LADSPA plugins on background threads introduced in v0.8.8.*
+)")
+      .def(
+          py::init([](std::string &pathToPluginFile, py::object parameterValues,
+                      std::optional<std::string> pluginName,
+                      float initializationTimeout) {
+            std::shared_ptr<ExternalPlugin<juce::LADSPAPluginFormat>>
+                plugin = std::make_shared<
+                    ExternalPlugin<juce::LADSPAPluginFormat>>(
+                    pathToPluginFile, pluginName, initializationTimeout);
+            py::cast(plugin).attr("__set_initial_parameter_values__")(
+                parameterValues);
+            return plugin;
+          }),
+          py::arg("path_to_plugin_file"),
+          py::arg("parameter_values") = py::none(),
+          py::arg("plugin_name") = py::none(),
+          py::arg("initialization_timeout") =
+              DEFAULT_INITIALIZATION_TIMEOUT_SECONDS)
+      .def("__repr__",
+           [](ExternalPlugin<juce::LADSPAPluginFormat> &plugin) {
+             std::ostringstream ss;
+             ss << "<pedalboard.LADSPAPlugin";
+             ss << " \"" << plugin.getName() << "\"";
+             ss << " at " << &plugin;
+             ss << ">";
+             return ss.str();
+           })
+      .def_static(
+          "get_plugin_names_for_file",
+          [](std::string filename) {
+            return getPluginNamesForFile<juce::LADSPAPluginFormat>(filename);
+          },
+          "Return a list of plugin names contained within a given LADSPA "
+          "plugin (i.e.: a \".ladspa\"). If the provided file cannot be "
+          "scanned, "
+          "an ImportError will be raised.")
+      .def_property_readonly_static(
+          "installed_plugins",
+          [](py::object /* cls */) { return findInstalledLADSPAPluginPaths(); },
+          "Return a list of paths to LADSPA plugins installed in the default "
+          "location on this system. This list may not be exhaustive, and "
+          "plugins in this list are not guaranteed to be compatible with "
+          "Pedalboard.")
+      .def_property_readonly(
+          "name",
+          [](ExternalPlugin<juce::LADSPAPluginFormat> &plugin) {
+            return plugin.getName().toStdString();
+          },
+          "The name of this plugin.")
+      .def_property(
+          "raw_state",
+          [](const ExternalPlugin<juce::LADSPAPluginFormat> &plugin) {
+            juce::MemoryBlock state;
+            plugin.getState(state);
+            return py::bytes((const char *)state.getData(), state.getSize());
+          },
+          [](ExternalPlugin<juce::LADSPAPluginFormat> &plugin,
+             const py::bytes &state) {
+            py::buffer_info info(py::buffer(state).request());
+            plugin.setState(info.ptr, static_cast<size_t>(info.size));
+          },
+          "A :py:class:`bytes` object representing the plugin's internal "
+          "state."
+          "For the LADSPA format, this is usually an XML-encoded string "
+          "prefixed with an 8-byte header and suffixed with a single null "
+          "byte."
+          ".. warning:: This property can be set to change the "
+          "plugin's internal state, but providing invalid data may cause the "
+          "plugin to crash, taking the entire Python process down with it.")
+      .def_property_readonly(
+          "descriptive_name",
+          [](ExternalPlugin<juce::LADSPAPluginFormat> &plugin) {
+            return plugin.foundPluginDescription.descriptiveName.toStdString();
+          },
+          "A more descriptive name for this plugin. This may be the same as "
+          "the 'name' field, but some plugins may provide an alternative "
+          "name.  *Introduced in v0.9.4.*")
+      .def_property_readonly(
+          "category",
+          [](ExternalPlugin<juce::LADSPAPluginFormat> &plugin) {
+            return plugin.foundPluginDescription.category.toStdString();
+          },
+          "A category that this plugin falls into, such as \"Dynamics\", "
+          "\"Reverbs\", etc.  *Introduced in v0.9.4.*")
+      .def_property_readonly(
+          "manufacturer_name",
+          [](ExternalPlugin<juce::LADSPAPluginFormat> &plugin) {
+            return plugin.foundPluginDescription.manufacturerName.toStdString();
+          },
+          "The name of the manufacturer of this plugin, as reported by the "
+          "plugin itself.  *Introduced in v0.9.4.*")
+      .def_property_readonly(
+          "version",
+          [](ExternalPlugin<juce::LADSPAPluginFormat> &plugin) {
+            return plugin.foundPluginDescription.version.toStdString();
+          },
+          "The version string for this plugin, as reported by the plugin "
+          "itself.  *Introduced in v0.9.4.*")
+      .def_property_readonly(
+          "is_instrument",
+          [](ExternalPlugin<juce::LADSPAPluginFormat> &plugin) {
+            return plugin.foundPluginDescription.isInstrument;
+          },
+          "True iff this plugin identifies itself as an instrument (generator, "
+          "synthesizer, etc) plugin.  *Introduced in v0.9.4.*")
+      .def_property_readonly(
+          "has_shared_container",
+          [](ExternalPlugin<juce::LADSPAPluginFormat> &plugin) {
+            return plugin.foundPluginDescription.hasSharedContainer;
+          },
+          "True iff this plugin is part of a multi-plugin "
+          "container.  *Introduced in v0.9.4.*")
+      .def_property_readonly(
+          "identifier",
+          [](ExternalPlugin<juce::LADSPAPluginFormat> &plugin) {
+            return plugin.foundPluginDescription.createIdentifierString()
+                .toStdString();
+          },
+          "A string that can be saved and used to uniquely identify this "
+          "plugin (and version) again.  *Introduced in v0.9.4.*")
+      .def_property_readonly(
+          "reported_latency_samples",
+          [](ExternalPlugin<juce::LADSPAPluginFormat> &plugin) {
+            return plugin.getLatencyHint();
+          },
+          "The number of samples of latency (delay) that this plugin reports "
+          "to introduce into the audio signal due to internal buffering "
+          "and processing. Pedalboard automatically compensates for this "
+          "latency during processing, so this property is present for "
+          "informational purposes. Note that not all plugins correctly report "
+          "the latency that they introduce, so this value may be inaccurate "
+          "(especially if the plugin reports 0).  *Introduced in v0.9.12.*")
+      .def_property_readonly(
+          "_parameters",
+          &ExternalPlugin<juce::LADSPAPluginFormat>::getParameters,
+          py::return_value_policy::reference_internal)
+      .def("_get_parameter",
+           &ExternalPlugin<juce::LADSPAPluginFormat>::getParameter,
+           py::return_value_policy::reference_internal)
+      .def("show_editor",
+           &ExternalPlugin<juce::LADSPAPluginFormat>::showEditor,
+           SHOW_EDITOR_DOCSTRING, py::arg("close_event") = py::none())
+      .def(
+          "process",
+          [](std::shared_ptr<Plugin> self, const py::array inputArray,
+             double sampleRate, unsigned int bufferSize, bool reset) {
+            return process(inputArray, sampleRate, {self}, bufferSize, reset);
+          },
+          EXTERNAL_PLUGIN_PROCESS_DOCSTRING, py::arg("input_array"),
+          py::arg("sample_rate"), py::arg("buffer_size") = DEFAULT_BUFFER_SIZE,
+          py::arg("reset") = true)
+      .def(
+          "__call__",
+          [](std::shared_ptr<Plugin> self, const py::array inputArray,
+             double sampleRate, unsigned int bufferSize, bool reset) {
+            return process(inputArray, sampleRate, {self}, bufferSize, reset);
+          },
+          "Run an audio or MIDI buffer through this plugin, returning "
+          "audio. Alias for :py:meth:`process`.",
+          py::arg("input_array"), py::arg("sample_rate"),
+          py::arg("buffer_size") = DEFAULT_BUFFER_SIZE, py::arg("reset") = true)
+      .def("process",
+           &ExternalPlugin<juce::LADSPAPluginFormat>::renderMIDIMessages,
+           EXTERNAL_PLUGIN_PROCESS_DOCSTRING, py::arg("midi_messages"),
+           py::arg("duration"), py::arg("sample_rate"),
+           py::arg("num_channels") = 2,
+           py::arg("buffer_size") = DEFAULT_BUFFER_SIZE,
+           py::arg("reset") = true)
+      .def("__call__",
+           &ExternalPlugin<juce::LADSPAPluginFormat>::renderMIDIMessages,
+           "Run an audio or MIDI buffer through this plugin, returning "
+           "audio. Alias for :py:meth:`process`.",
+           py::arg("midi_messages"), py::arg("duration"),
+           py::arg("sample_rate"), py::arg("num_channels") = 2,
+           py::arg("buffer_size") = DEFAULT_BUFFER_SIZE,
+           py::arg("reset") = true)
+      .def_readwrite(
+          "_reload_type",
+          &ExternalPlugin<juce::LADSPAPluginFormat>::reloadType,
           "The behavior that this plugin exhibits when .reset() is called. "
           "This is an internal attribute which gets set on plugin "
           "instantiation and should only be accessed for debugging and "

--- a/pedalboard/ExternalPlugin.h
+++ b/pedalboard/ExternalPlugin.h
@@ -180,7 +180,7 @@ inline std::vector<std::string> findInstalledVSTPluginPaths() {
   return pluginPaths;
 }
 
-#if JUCE_LINUX
+#if JUCE_PLUGINHOST_LADSPA && JUCE_LINUX
 inline std::vector<std::string> findInstalledLADSPAPluginPaths() {
   juce::MessageManager::getInstance();
   juce::LADSPAPluginFormat format;
@@ -2095,7 +2095,7 @@ see :class:`pedalboard.VST3Plugin`.)
           "testing.");
 #endif
 
-#if JUCE_PLUGINHOST_LADSPA &&JUCE_LINUX
+#if JUCE_PLUGINHOST_LADSPA && JUCE_LINUX
   py::class_<ExternalPlugin<juce::LADSPAPluginFormat>, AbstractExternalPlugin,
              std::shared_ptr<ExternalPlugin<juce::LADSPAPluginFormat>>>(
       m, "LADSPAPlugin",

--- a/pedalboard/ExternalPlugin.h
+++ b/pedalboard/ExternalPlugin.h
@@ -180,6 +180,7 @@ inline std::vector<std::string> findInstalledVSTPluginPaths() {
   return pluginPaths;
 }
 
+#if JUCE_LINUX
 inline std::vector<std::string> findInstalledLADSPAPluginPaths() {
   juce::MessageManager::getInstance();
   juce::LADSPAPluginFormat format;
@@ -191,6 +192,7 @@ inline std::vector<std::string> findInstalledLADSPAPluginPaths() {
   }
   return pluginPaths;
 }
+#endif
 
 /**
  * Given a py::object representing a Python list object filled with Tuple[bytes,

--- a/pedalboard/ExternalPlugin.h
+++ b/pedalboard/ExternalPlugin.h
@@ -2095,7 +2095,7 @@ see :class:`pedalboard.VST3Plugin`.)
           "testing.");
 #endif
 
-#if JUCE_LINUX
+#if JUCE_PLUGINHOST_LADSPA &&JUCE_LINUX
   py::class_<ExternalPlugin<juce::LADSPAPluginFormat>, AbstractExternalPlugin,
              std::shared_ptr<ExternalPlugin<juce::LADSPAPluginFormat>>>(
       m, "LADSPAPlugin",

--- a/pedalboard/_pedalboard.py
+++ b/pedalboard/_pedalboard.py
@@ -749,6 +749,14 @@ except ImportError:
     # (i.e.: any platform that's not macOS.)
     pass
 
+try:
+    from pedalboard_native import LADSPAPlugin # type: ignore
+
+    _AVAILABLE_PLUGIN_CLASSES.append(LADSPAPlugin)
+except ImportError:
+    # We may be on a system that doesn't have native VST3Plugin support.
+    pass
+
 
 def load_plugin(
     path_to_plugin_file: str,

--- a/pedalboard/_pedalboard.py
+++ b/pedalboard/_pedalboard.py
@@ -750,7 +750,7 @@ except ImportError:
     pass
 
 try:
-    from pedalboard_native import LADSPAPlugin # type: ignore
+    from pedalboard_native import LADSPAPlugin  # type: ignore
 
     _AVAILABLE_PLUGIN_CLASSES.append(LADSPAPlugin)
 except ImportError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,4 +20,4 @@ before-all = "yum install -y libsndfile libX11-devel libXrandr-devel libXinerama
 # Use apk instead of yum when building on Alpine Linux
 # (Note: this is experimental, as most VSTs require glibc and thus Alpine Linux isn't that useful)
 select = "*-musllinux*"
-before-all = "apk add libsndfile libx11-dev libxrandr-dev libxinerama-dev libxrender-dev libxcomposite-dev libxinerama-dev libxcursor-dev freetype-dev libexecinfo-dev alsa-lib-dev ladspa"
+before-all = "apk add libsndfile libx11-dev libxrandr-dev libxinerama-dev libxrender-dev libxcomposite-dev libxinerama-dev libxcursor-dev freetype-dev libexecinfo-dev alsa-lib-dev"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,10 +14,10 @@ build-backend = "setuptools.build_meta"
 
 # See: https://cibuildwheel.readthedocs.io/en/stable/options/#examples
 [tool.cibuildwheel.linux]
-before-all = "yum install -y libsndfile libX11-devel libXrandr-devel libXinerama-devel libXrender-devel libXcomposite-devel libXinerama-devel libXcursor-devel freetype-devel alsa-lib-devel"
+before-all = "yum install -y libsndfile libX11-devel libXrandr-devel libXinerama-devel libXrender-devel libXcomposite-devel libXinerama-devel libXcursor-devel freetype-devel alsa-lib-devel ladspa-devel"
 
 [[tool.cibuildwheel.overrides]]
 # Use apk instead of yum when building on Alpine Linux
 # (Note: this is experimental, as most VSTs require glibc and thus Alpine Linux isn't that useful)
 select = "*-musllinux*"
-before-all = "apk add libsndfile libx11-dev libxrandr-dev libxinerama-dev libxrender-dev libxcomposite-dev libxinerama-dev libxcursor-dev freetype-dev libexecinfo-dev alsa-lib-dev"
+before-all = "apk add libsndfile libx11-dev libxrandr-dev libxinerama-dev libxrender-dev libxcomposite-dev libxinerama-dev libxcursor-dev freetype-dev libexecinfo-dev alsa-lib-dev ladspa"

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ ALL_CPPFLAGS.extend(
         "-DJucePlugin_Build_Unity=0",
         # "-DJUCE_PLUGINHOST_VST=1", # Include for VST2 support, not licensed by Steinberg
         # "-DJUCE_PLUGINHOST_VST3=1", # Disable the built-in VST3 support, as we include our own.
-        # "-DJUCE_PLUGINHOST_LADSPA=1", # Include for LADSPA plugin support, Linux only.
+        "-DJUCE_PLUGINHOST_LADSPA=1", # Include for LADSPA plugin support, Linux only.
         "-DJUCE_DISABLE_JUCE_VERSION_PRINTING=1",
         "-DJUCE_WEB_BROWSER=0",
         "-DJUCE_USE_CURL=0",

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ ALL_CPPFLAGS.extend(
         "-DJucePlugin_Build_Unity=0",
         # "-DJUCE_PLUGINHOST_VST=1", # Include for VST2 support, not licensed by Steinberg
         # "-DJUCE_PLUGINHOST_VST3=1", # Disable the built-in VST3 support, as we include our own.
-        "-DJUCE_PLUGINHOST_LADSPA=1", # Include for LADSPA plugin support, Linux only.
+        "-DJUCE_PLUGINHOST_LADSPA=1",  # Include for LADSPA plugin support, Linux only
         "-DJUCE_DISABLE_JUCE_VERSION_PRINTING=1",
         "-DJUCE_WEB_BROWSER=0",
         "-DJUCE_USE_CURL=0",

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ ALL_INCLUDES.extend(
     ]
 )
 
-if platform.system() == "Linux":
+if platform.system() == "Linux" and "musllinux" not in os.getenv("CIBW_BUILD", ""):
     ALL_CPPFLAGS.extend(
         [
             "-DJUCE_PLUGINHOST_LADSPA=1",  # Include for LADSPA plugin support, Linux only

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,6 @@ ALL_CPPFLAGS.extend(
         "-DJucePlugin_Build_Unity=0",
         # "-DJUCE_PLUGINHOST_VST=1", # Include for VST2 support, not licensed by Steinberg
         # "-DJUCE_PLUGINHOST_VST3=1", # Disable the built-in VST3 support, as we include our own.
-        "-DJUCE_PLUGINHOST_LADSPA=1",  # Include for LADSPA plugin support, Linux only
         "-DJUCE_DISABLE_JUCE_VERSION_PRINTING=1",
         "-DJUCE_WEB_BROWSER=0",
         "-DJUCE_USE_CURL=0",
@@ -87,6 +86,13 @@ ALL_INCLUDES.extend(
         "JUCE/modules/juce_audio_processors/format_types/VST3_SDK/",
     ]
 )
+
+if platform.system() == "Linux":
+    ALL_CPPFLAGS.extend(
+        [
+            "-DJUCE_PLUGINHOST_LADSPA=1",  # Include for LADSPA plugin support, Linux only
+        ]
+    )
 
 if "musllinux" in os.getenv("CIBW_BUILD", ""):
     # For Alpine/musllinux compatibility:


### PR DESCRIPTION
## Rationale 

Right now spotify/pedalboard does not support LADSPA plugins https://github.com/spotify/pedalboard/issues/240, this PR is for enabling LADSPA support.

## What I confirmed

Loading a LADSPA plugin and applying it.

## Current status

This PR still has the following issues or behaviors

1. `findInstalledLADSPAPluginPaths` may not work
2.  Not confirming all properties `py::class_<ExternalPlugin<juce::LADSPAPluginFormat>` work as expected
3. For some reason, I had to fix JUCE repo as follows:

```diff
diff --git a/modules/juce_core/system/juce_StandardHeader.h b/modules/juce_core/system/juce_StandardHeader.h
index 8e536f3dc3..80b3050a8f 100644
--- a/modules/juce_core/system/juce_StandardHeader.h
+++ b/modules/juce_core/system/juce_StandardHeader.h
@@ -63,6 +63,7 @@
 #include <sstream>
 #include <typeindex>
 #include <unordered_set>
+#include <utility>
 #include <vector>

 //==============================================================================
```

Maybe it's just due to my Docker container issue. However AFAIK there's a corresponding JUCE issue and with newer versions of JUCE already fixed it.

4. LADSPA plugin parameters value range is always normalized.

For example, when I try to check LADSPA plugins by calling `analyseplugin` command,

```
root@519dd78036e0:/app# analyseplugin loudmax_test/la_LoudMax64.so

...
Plugin Name: "LoudMax Stereo"
Plugin Label: "ldmx_stereo"
Plugin Unique ID: 5502
Maker: "Thomas Mundt"
Copyright: "v1.45 (c) 2023 Thomas Mundt"
Must Run Real-Time: No
Has activate() Function: Yes
Has deactivate() Function: No
Has run_adding() Function: No
Environment: Normal or Hard Real-Time
Ports:  "Threshold (dB)" input, control, -30 to 0, default 0
        "Output (dB)" input, control, -30 to 0, default 0
        "Inter-Sample Peaks" input, control, toggled, default 0
        "latency" output, control
        "Input (Left)" input, audio
        "Output (Left)" output, audio
        "Input (Right)" input, audio
        "Output (Right)" output, audio
...
```

`"Threshold (dB)" input, control, -30 to 0, default 0`. However when I load it via pedalboard, the value range is between 0 and 1.
We can still set the parameter, but we need to calculate the equivalent normalized value from desired original value :( 

```
>>> ladspa.parameters
{'threshold_db': <pedalboard.AudioProcessorParameter name="Threshold (dB)" raw_value=0 value=-30.0000 range=(0.0, 1.0, 0.001)>, 'output_db': <pedalboard.AudioProcessorParameter name="Output (dB)" raw_value=0 value=0.0000 range=(0.0,
1)>, 'inter_sample_peaks': <pedalboard.AudioProcessorParameter name="Inter-Sample Peaks" raw_value=0 value=0.0000 range=(0.0, 1.0, 0.001)>, 'latency': <pedalboard.AudioProcessorParameter name="latency" raw_value=0 value=55.0000 rang
0, 0.001)>}
```


## TODO

For CI: 
- [x] Fix  Ruff lint issues
  - I don't know why existing codes already have format errors 🤔 
- [x] Fix C++ format issues
- [ ] Add `ladspa-sdk` on build environment
- [ ] Add LADSPA flag only for Linux

For the further development:

- [ ] Find a way we can avoid using normalized LADSPA parameters
- [ ] Find a way to allow folks to use forked version of this fix
  - I think it's a rare case that people want LADSPA and it may take long time to make this PR mergeable
- [ ] Add test code if it's worth merging to the spotify/pedalboard
